### PR TITLE
Add option to show ed2k while using api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ To add all mkv files from directory resursively to mylist use:
 Where
     * **"password"** is your anidb password
     * **"username"** is your anidb username
-    * **"apikey"** is anidb upd api key, that you can set at http://anidb.net/perl-bin/animedb.pl?show=profile. If no key is provided, unencrypted connection will be used.
+    * **"apikey"** is anidb upd api key, that you can set at https://anidb.net/user/setting. If no key is provided, unencrypted connection will be used.
 
 Optionally, if you don't provide password or username, you will be prompted to input them.
 
@@ -84,7 +84,11 @@ To set files to a specified state use:
 
 .. code-block:: bash
         
-        anidbcli -r -e mkv api -u "username" -p "password" -k "apikey" --state 0 -a "path/to/directory"
+        anidbcli -r -e mkv api -u "username" -p "password" -k "apikey" --state 0 --show-ed2k -a "path/to/directory"
+
+Where
+    * **"show-ed2k"** is an optional parameter to show print out ed2k links, while adding/renaming files.
+    * **"state"** is your desired MyList file state (see https://wiki.anidb.net/Filestates).
 
 The number 0 can be substituted for different states:
         * 0 is unknown (default)

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ To set files to a specified state use:
         anidbcli -r -e mkv api -u "username" -p "password" -k "apikey" --state 0 --show-ed2k -a "path/to/directory"
 
 Where
-    * **"show-ed2k"** is an optional parameter to show print out ed2k links, while adding/renaming files.
+    * **"show-ed2k"** is an optional parameter to show/print out ed2k links, while adding/renaming files.
     * **"state"** is your desired MyList file state (see https://wiki.anidb.net/Filestates).
 
 The number 0 can be substituted for different states:

--- a/anidbcli/cli.py
+++ b/anidbcli/cli.py
@@ -58,9 +58,10 @@ def ed2k(ctx , files, clipboard):
 @click.option("--persistent", "-t", default=False, is_flag=True, help="Save session info for next invocations with this parameter. (35 minutes session lifetime)")
 @click.option("--abort", default=False, is_flag=True, help="Abort if an usable tag is empty.")
 @click.option("--state", default=0, help="Specify the file state. (0-4)")
+@click.option("--show-ed2k", default=False, is_flag=True, help="Show ed2k link of processed file (while adding or renaming files).")
 @click.argument("files", nargs=-1, type=click.Path(exists=True))
 @click.pass_context
-def api(ctx, username, password, apikey, add, unwatched, rename, files, keep_structure, date_format, delete_empty, link, softlink, persistent, abort, state):
+def api(ctx, username, password, apikey, add, unwatched, rename, files, keep_structure, date_format, delete_empty, link, softlink, persistent, abort, state, show_ed2k):
     if (not add and not rename):
         ctx.obj["output"].info("Nothing to do.")
         return
@@ -71,7 +72,7 @@ def api(ctx, username, password, apikey, add, unwatched, rename, files, keep_str
         ctx.obj["output"].error(e)
         exit(1)
     pipeline = []
-    pipeline.append(operations.HashOperation(ctx.obj["output"]))
+    pipeline.append(operations.HashOperation(ctx.obj["output"], show_ed2k))
     if add:
         pipeline.append(operations.MylistAddOperation(conn, ctx.obj["output"], state, unwatched))
     if rename:
@@ -82,6 +83,7 @@ def api(ctx, username, password, apikey, add, unwatched, rename, files, keep_str
         file_obj = {}
         file_obj["path"] = file
         ctx.obj["output"].info("Processing file \"" + file +"\"")
+
         for operation in pipeline:
             res = operation.Process(file_obj)
             if not res: # Critical error, cannot proceed with pipeline

--- a/anidbcli/libed2k.py
+++ b/anidbcli/libed2k.py
@@ -7,12 +7,14 @@ from joblib import Parallel, delayed
 CHUNK_SIZE = 9728000 # 9500KB
 MAX_CORES = 4
 
-def get_ed2k_link(file_path):
+def get_ed2k_link(file_path, file_hash=None):		
     name = os.path.basename(file_path)
     filesize = os.path.getsize(file_path)
-    md4 = hash_file(file_path)
+    if file_hash is None:
+        md4 = hash_file(file_path)
+    else:
+        md4 = file_hash
     return "ed2k://|file|%s|%d|%s|" % (name,filesize, md4)
-
 
 def md4_hash(data):
         m = hashlib.new('md4')

--- a/anidbcli/operations.py
+++ b/anidbcli/operations.py
@@ -50,7 +50,6 @@ class MylistAddOperation(Operation):
                     self.output.success("Mylist entry state updated.")
                 else:
                     self.output.warning("Could not mark as watched.")
-
             else:
                 self.output.error("Couldn't add to mylist: %s" % res["data"])
         except Exception as e:
@@ -59,8 +58,9 @@ class MylistAddOperation(Operation):
         return True
 
 class HashOperation(Operation):
-    def __init__(self, output):
+    def __init__(self, output, show_ed2k):
         self.output = output
+        self.show_ed2k = show_ed2k
     def Process(self, file):
         try:
             link = libed2k.hash_file(file["path"])
@@ -70,6 +70,8 @@ class HashOperation(Operation):
         file["ed2k"] = link
         file["size"] = os.path.getsize(file["path"])
         self.output.success("Generated ed2k link.")
+        if self.show_ed2k:
+            self.output.info(libed2k.get_ed2k_link(file["path"], file["ed2k"]))
         return True
 
 


### PR DESCRIPTION
I wanted to be able to see the ed2k links of the currently added file (and not use the ed2k option).

Updated a link in the README.
A few changes in the code, which may appear to be a shameless perversion, due to me being very new into python.
Everything else behaves to same.