### PR TITLE
[in progress] add extra helper tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
 
 setup(
     name='anidbcli',
-    version='1.64',
+    version='1.65',
     keywords='Anidb UDP API CLI client ed2k rename mylist',
     description='Simple CLI for managing your anime collection using AniDB UDP API.',
     long_description=long_description,
@@ -26,7 +26,8 @@ setup(
         'pycryptodome',
         'colorama',
         'pyperclip',
-        'joblib'
+        'joblib',
+        'fuzzywuzzy'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Try to resolve my #21 .

* add helper tags: `year_start`,`year_end`,`resolution_abbr`
* preserve UDP list delimiter by converting ' to §
* add fuzzywuzzy import to-do the string processing
* add fuzzy selected tags: `a_english_alt`,`a_romaji_alt`,
* add short version tags via: `a_english_short`,`a_romaji_short`,`a_english_shorter`,`a_romaji_shorter`

PS: The UDP list delimiter gets lost after parse import, so i replaced it by the unused AniDB char `§`. This way later on we can safely operate on list.